### PR TITLE
Enable unicode characters in identifiers

### DIFF
--- a/Julia.tmLanguage
+++ b/Julia.tmLanguage
@@ -155,7 +155,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>([a-zA-Z0-9_]+!?)\w*\(</string>
+					<string>(\w+!?)\w*\(</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -190,7 +190,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>^\s*([a-zA-Z0-9\._]+!?)(?=.*\)\s*=(?!=))</string>
+					<string>^\s*(\w+!?)(?=.*\)\s*=(?!=))</string>
 					<key>captures</key>
 					<dict>
 						<key>1</key>
@@ -202,7 +202,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(function|macro)\s+([a-zA-Z0-9_\.]+!?)\b</string>
+					<string>\b(function|macro)\s+(\w+!?)\b</string>
 					<key>captures</key>
 					<dict>
 						<key>1</key>
@@ -333,7 +333,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>(?:\.(?=[a-zA-Z])|\.\.+)</string>
+					<string>(?:\.(?=\p{Alpha})|\.\.+)</string>
 					<key>name</key>
 					<string>keyword.operator.dots.julia</string>
 				</dict>
@@ -397,7 +397,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>(?&lt;![a-zA-Z0-9:&lt;]:)(?&lt;=:)[a-zA-Z_][a-zA-Z0-9_]*\b</string>
+					<string>(?&lt;![\p{Alnum}:&lt;]:)(?&lt;=:)[\p{Alpha}_]\w*\b</string>
 					<key>name</key>
 					<string>string.quoted.symbol.julia</string>
 				</dict>


### PR DESCRIPTION
Example code for which this fixes highlighting and symbol detection, in the function name and in the symbol literal (:φs):

    function example_fn_φ(t, φs)
        t[:φs] = φs
    end
