### PR TITLE
adding ≤ ≥ ≠

### DIFF
--- a/Julia.tmLanguage
+++ b/Julia.tmLanguage
@@ -322,7 +322,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>(?:&gt;|&lt;|&gt;=|&lt;=|==|!=|\.&gt;|\.&lt;|\.&gt;=|\.&gt;=|\.==|\.!=|\.=|\.!|&lt;:|:&gt;)</string>
+					<string>(?:&gt;|&lt;|&gt;=|≥|&lt;=|≤|==|!=|≠|\.&gt;|\.&lt;|\.&gt;=|\.≥|\.&gt;=|\.≤|\.==|\.!=|\.≠|\.=|\.!|&lt;:|:&gt;)</string>
 					<key>name</key>
 					<string>keyword.operator.relation.julia</string>
 				</dict>


### PR DESCRIPTION
Adding symbols `≤`, `≥`, `≠`, `.≤`, `.≥`, and `.≠` alongside `<=`, `>=`, `!=`, `.<=`, `.>=`, and `.!=` so that they highlight the same way. 